### PR TITLE
Publish api classes and consts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-legacy-api",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Legacy API support for TestCafe",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-legacy-api",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Legacy API support for TestCafe",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,15 @@
+import { readSync as read } from 'read-file-relative';
 import CompilerAdapter from './compiler';
+import TestRun from './test-run';
+import TEST_RUN_ERROR_TYPE from './test-run-error/type';
+import TestRunErrorFormattableAdapter from './test-run-error/formattable-adapter';
+
+const CLIENT_RUNNER_SCRIPT = read('./client/index.js');
 
 export default {
-    Compiler: CompilerAdapter
+    TEST_RUN_ERROR_TYPE:            TEST_RUN_ERROR_TYPE,
+    CLIENT_RUNNER_SCRIPT:           CLIENT_RUNNER_SCRIPT,
+    Compiler:                       CompilerAdapter,
+    TestRun:                        TestRun,
+    TestRunErrorFormattableAdapter: TestRunErrorFormattableAdapter
 };


### PR DESCRIPTION
/cc @inikulin 

I suppose we can increase the version to 1.0.2 (not to 1.1.0) since the v1.x version was not used in the `testcafe` repo yet
