### PR TITLE
Add TestRun.start function. Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-legacy-api",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Legacy API support for TestCafe",
   "main": "lib/index.js",
   "scripts": {

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -120,6 +120,9 @@ export default class LegacyTestRun extends Session {
 
         ctx.redirect(this.browserConnection.idleUrl);
     }
+
+    async start () {
+    }
 }
 
 // Service message handlers

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -122,6 +122,7 @@ export default class LegacyTestRun extends Session {
     }
 
     async start () {
+        // NOTE: required to keep API similar to TestRun. Just do nothing here.
     }
 }
 


### PR DESCRIPTION
/cc @inikulin 
We need this to synchronize LegacyTestRun with [this](https://github.com/DevExpress/testcafe/pull/744) changes in TestRun
