### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-legacy-api",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "description": "Legacy API support for TestCafe",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
/cc @inikulin 
We are increasing the `major` version because of https://github.com/DevExpress/testcafe-legacy-api/pull/20
