### PR TITLE
Add pageUrl and authCredentials fields into a compiled test object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-legacy-api",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Legacy API support for TestCafe",
   "main": "lib/index.js",
   "scripts": {

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -144,11 +144,13 @@ export default class CompilerAdapter {
         };
 
         return Object.keys(compiled.testsStepData).map(testName => ({
-            name:        testName,
-            sourceIndex: this.cache.sourceIndex,
-            stepData:    compiled.testsStepData[testName],
-            fixture:     fixture,
-            isLegacy:    true
+            name:            testName,
+            sourceIndex:     this.cache.sourceIndex,
+            stepData:        compiled.testsStepData[testName],
+            fixture:         fixture,
+            isLegacy:        true,
+            pageUrl:         fixture.pageUrl,
+            authCredentials: fixture.authCredentials
         }));
     }
 

--- a/test/server/compiler-adapter-test.js
+++ b/test/server/compiler-adapter-test.js
@@ -55,6 +55,9 @@ describe('Legacy compiler adapter', function () {
                 expect(Array.isArray(test1.sourceIndex)).to.be.true;
                 expect(sanitize(test1.stepData.js)).eql(sanitize(expectedTest1Js));
                 expect(test1.stepData.names).eql(['1.Do smthg cool', '2.Stop here']);
+                expect(test1.pageUrl).eql('http://my.page.url/');
+                expect(test1.authCredentials.username).eql('myLogin');
+                expect(test1.authCredentials.password).eql('myPassword');
 
                 var test2           = getTestByName(tests, 'I want more tests!');
                 var expectedTest2Js = read('./data/compiler/compile/test2_expected.js');


### PR DESCRIPTION
It's required because of https://github.com/DevExpress/testcafe/pull/1301
/cc @inikulin 