### PR TITLE
Fix after iframes logic update in hammerhead

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-legacy-api",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Legacy API support for TestCafe",
   "main": "lib/index.js",
   "scripts": {

--- a/src/client/test-run/iframe.js.mustache
+++ b/src/client/test-run/iframe.js.mustache
@@ -62,11 +62,20 @@
     (function () {
         var testCafeLegacyRunner = window['%testCafeLegacyRunner%'];
 
-        var sandboxedJQuery          = testCafeLegacyRunner.sandboxedJQuery;
-        var extendJQuerySelectors    = testCafeLegacyRunner.extendJQuerySelectors;
-        var jQueryDataMethodProxy    = testCafeLegacyRunner.jQueryDataMethodProxy;
-        var iframeDispatcher         = testCafeLegacyRunner.iframeDispatcher;
+        var sandboxedJQuery       = testCafeLegacyRunner.sandboxedJQuery;
+        var extendJQuerySelectors = testCafeLegacyRunner.extendJQuerySelectors;
+        var jQueryDataMethodProxy = testCafeLegacyRunner.jQueryDataMethodProxy;
+        var iframeDispatcher      = testCafeLegacyRunner.iframeDispatcher;
 
+        var documentAddEventListener = window['%hammerhead%'].nativeMethods.documentAddEventListener;
+
+        function initJQuery () {
+            sandboxedJQuery.init(window, undefined);
+            extendJQuerySelectors(sandboxedJQuery.jQuery);
+
+            $ = jQuery = sandboxedJQuery.jQuery;
+            jQueryDataMethodProxy.setup($);
+        }
 
         testCafeLegacyRunner.SETTINGS.set({
             TAKE_SCREENSHOTS_ON_FAILS:     {{{takeScreenshotsOnFails}}},
@@ -80,13 +89,10 @@
             ADDITIONAL_REQUESTS_COLLECTION_DELAY: 100
         });
 
-        window['%hammerhead%'].nativeMethods.documentAddEventListener.call(document, "DOMContentLoaded", function() {
-            sandboxedJQuery.init(window, undefined);
-            extendJQuerySelectors(sandboxedJQuery.jQuery);
-
-            $ = jQuery = sandboxedJQuery.jQuery;
-            jQueryDataMethodProxy.setup($);
-        });
+        if (!document.documentElement)
+            documentAddEventListener.call(document, "DOMContentLoaded", initJQuery);
+        else
+            initJQuery();
 
         //NOTE: Override these methods to suppress native dialogs until the test runner in the iFrame gets initialized. (T188994)
         window.alert = window.confirm = window.prompt = new Function();

--- a/src/client/test-run/iframe.js.mustache
+++ b/src/client/test-run/iframe.js.mustache
@@ -80,11 +80,13 @@
             ADDITIONAL_REQUESTS_COLLECTION_DELAY: 100
         });
 
-        sandboxedJQuery.init(window, undefined);
-        extendJQuerySelectors(sandboxedJQuery.jQuery);
+        window['%hammerhead%'].nativeMethods.documentAddEventListener.call(document, "DOMContentLoaded", function() {
+            sandboxedJQuery.init(window, undefined);
+            extendJQuerySelectors(sandboxedJQuery.jQuery);
 
-        $ = jQuery = sandboxedJQuery.jQuery;
-        jQueryDataMethodProxy.setup($);
+            $ = jQuery = sandboxedJQuery.jQuery;
+            jQueryDataMethodProxy.setup($);
+        });
 
         //NOTE: Override these methods to suppress native dialogs until the test runner in the iFrame gets initialized. (T188994)
         window.alert = window.confirm = window.prompt = new Function();


### PR DESCRIPTION
### Changes:
1. Fix `sandboxedJQuery` initialization in `iframe` script in case of `!document.documentElement`.
### Fixed Errors (IE11, Edge)
`Uncaught JavaScript error Unable to get property 'contains' of undefined or null reference` 
in **`src/client/sandboxed-jquery.js`**, and other
`Uncaught JavaScript error Unable to get property '...' of undefined or null reference`
errors because of `document.documentElement === null`