### PR TITLE
Add page dimensions for screenshots; Bump version (v3.1.11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-legacy-api",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "description": "Legacy API support for TestCafe",
   "main": "lib/index.js",
   "scripts": {

--- a/src/client/runner.js
+++ b/src/client/runner.js
@@ -220,8 +220,16 @@ Runner.prototype._onTakeScreenshot = function (e) {
                 var msg = {
                     cmd:        COMMAND.takeScreenshot,
                     customPath: e.filePath,
-                    innerWidth:  window.innerWidth,
-                    innerHeight: window.innerHeight
+
+                    pageDimensions: {
+                        dpr:            window.devicePixelRatio || 1,
+                        innerWidth:     window.innerWidth,
+                        innerHeight:    window.innerHeight,
+                        documentWidth:  document.documentElement.clientWidth,
+                        documentHeight: document.documentElement.clientHeight,
+                        bodyWidth:      document.body.clientWidth,
+                        bodyHeight:     document.body.clientHeight
+                    }
                 };
 
                 transport.asyncServiceMsg(msg, resolve);


### PR DESCRIPTION
Added `pageDimensions` to reflect current code in the `master`: https://github.com/DevExpress/testcafe/blob/master/src/client/driver/command-executors/browser-manipulation/index.js#L71