### PR TITLE
Fix missing dependencies (moved from devDependencies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,8 @@
     "highlight-es": "^1.0.0",
     "multiline": "^1.0.2",
     "publish-please": "^5.5.2",
-    "read-file-relative": "^1.2.0",
     "rollup": "^2.34.1",
     "rollup-plugin-typescript2": "^0.29.0",
-    "testcafe-hammerhead": "^17.0.1",
     "typescript": "^4.1.2"
   },
   "dependencies": {
@@ -58,7 +56,9 @@
     "parse5": "^2.1.5",
     "pify": "^2.3.0",
     "pinkie": "^2.0.1",
-    "strip-bom": "^2.0.0"
+    "read-file-relative": "^1.2.0",
+    "strip-bom": "^2.0.0",
+    "testcafe-hammerhead": "^17.0.1"
   },
   "files": [
     "lib"


### PR DESCRIPTION
`read-file-relative` and `testcafe-hammerhead` are not listed in the dependencies (only in the devDependencies), even though they are required. This prevents running TestCafe via Yarn 2, which is more strict about dependencies.

See also https://github.com/DevExpress/testcafe/pull/5872