### PR TITLE
bump: async version updated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "testcafe-legacy-api",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "testcafe-legacy-api",
-      "version": "5.1.8",
+      "version": "5.1.9",
       "license": "MIT",
       "dependencies": {
-        "async": "3.2.3",
+        "async": "^3.2.6",
         "dedent": "^0.6.0",
         "highlight-es": "^1.0.0",
         "lodash": "^4.17.21",
@@ -657,9 +657,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "node_modules/async-done": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-legacy-api",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "description": "Legacy API support for TestCafe",
   "main": "lib/index.js",
   "scripts": {
@@ -43,7 +43,7 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
-    "async": "3.2.3",
+    "async": "^3.2.6",
     "dedent": "^0.6.0",
     "highlight-es": "^1.0.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Fix https://nvd.nist.gov/vuln/detail/CVE-2024-39249 async package.

Closes https://github.com/DevExpress/testcafe-legacy-api/issues/83